### PR TITLE
AMBIT database data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _site/
 .bundle/
 vendor/
 _data/nanomiles/data.tsv
+ambit.json

--- a/_config.yml
+++ b/_config.yml
@@ -28,3 +28,4 @@ page_gen:
   dir: "substance/erm/"
   name_expr: "record['id']"
   title_expr: "record['title']"
+- data: "databases"

--- a/_data/databases/HARMLESS.yml
+++ b/_data/databases/HARMLESS.yml
@@ -1,0 +1,1 @@
+title: HARMLESS

--- a/_data/databases/RISKGONE.yml
+++ b/_data/databases/RISKGONE.yml
@@ -1,0 +1,1 @@
+title: RISKGONE

--- a/_data/databases/SBD4NANO.yml
+++ b/_data/databases/SBD4NANO.yml
@@ -1,0 +1,1 @@
+title: SBD4NANO

--- a/_data/erm/ERM00000062.yml
+++ b/_data/erm/ERM00000062.yml
@@ -8,18 +8,21 @@ nanoviz:
 tags: erm:ERM00000062
 cas: 1317-70-0
 supplier:
- - name: Sigma Aldrich
-   code: 637254
-   batch: MKCK-4358
-a: npo:NPO_1486 # TODO It is not technically a nanoparticle but a nanoparticle
+  - name: Sigma Aldrich
+    code: 637254
+    batch: MKCK-4358
+a: npo:NPO_1486
 otherLinks:
- - url: https://riskgone.eu/wp-content/uploads/sites/11/2022/02/RiskGONE-D5.1.pdf
-   title: Report on the final harmonised SOPs used to propose amendments to the existing OECD TGs
-   date: 2021-12-29
-   type: deliverable
-   format: pdf
- - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
-   title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
-   date: 2023-08-01
-   type: poster
-   format: pdf
+  - url: https://riskgone.eu/wp-content/uploads/sites/11/2022/02/RiskGONE-D5.1.pdf
+    title: Report on the final harmonised SOPs used to propose amendments to the
+      existing OECD TGs
+    date: 2021-12-29
+    type: deliverable
+    format: pdf
+  - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
+    title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
+    date: 2023-08-01
+    type: poster
+    format: pdf
+  - databases:
+      - RISKGONE

--- a/_data/erm/ERM00000063.yml
+++ b/_data/erm/ERM00000063.yml
@@ -6,23 +6,26 @@ chemicalComposition: ZnO
 tags: doi:10.3389/FTOX.2022.981701 erm:ERM00000063
 cas: 1314-13-2
 supplier:
- - name: Sigma Aldrich
-   code: 721077
-   batch: MKCK-4155
+  - name: Sigma Aldrich
+    code: 721077
+    batch: MKCK-4155
 scholarlyArticleDOI: 10.3389/FTOX.2022.981701 10.1016/J.CHEMOSPHERE.2023.140975
-a: npo:NPO_1542 # TODO It is not technically a nanoparticle but a nanoparticle 
+a: npo:NPO_1542
 otherLinks:
- - url: https://riskgone.eu/wp-content/uploads/sites/11/2022/02/RiskGONE-D5.1.pdf
-   title: Report on the final harmonised SOPs used to propose amendments to the existing OECD TGs
-   date: 2021-12-29
-   type: deliverable
-   format: pdf
- - url: https://www.sigmaaldrich.com/NL/en/sds/aldrich/721077
-   title: SAFETY DATA SHEET - Sigma-Aldrich
-   type: other
-   format: pdf
- - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
-   title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
-   date: 2023-08-01
-   type: poster
-   format: pdf
+  - url: https://riskgone.eu/wp-content/uploads/sites/11/2022/02/RiskGONE-D5.1.pdf
+    title: Report on the final harmonised SOPs used to propose amendments to the
+      existing OECD TGs
+    date: 2021-12-29
+    type: deliverable
+    format: pdf
+  - url: https://www.sigmaaldrich.com/NL/en/sds/aldrich/721077
+    title: SAFETY DATA SHEET - Sigma-Aldrich
+    type: other
+    format: pdf
+  - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
+    title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
+    date: 2023-08-01
+    type: poster
+    format: pdf
+  - databases:
+      - RISKGONE

--- a/_data/erm/ERM00000064.yml
+++ b/_data/erm/ERM00000064.yml
@@ -4,26 +4,31 @@ id: ERM00000064
 tag: erm:ERM00000064
 tags: erm:ERM00000064 10.3389/FTOX.2022.981701
 supplier:
- - name: JRC
-   code: 721077
-   batch: JRCNM01005a
+  - name: JRC
+    code: 721077
+    batch: JRCNM01005a
 chemicalComposition: TiO2
 scholarlyArticleDOI: 10.3389/FTOX.2022.981701 10.1016/J.CHEMOSPHERE.2023.140975
 a: npo:NPO_1486
 otherLinks:
- - url: https://riskgone.eu/wp-content/uploads/sites/11/2022/02/RiskGONE-D5.1.pdf
-   title: Report on the final harmonised SOPs used to propose amendments to the existing OECD TGs
-   date: 2021-12-29
-   type: deliverable
-   format: pdf
- - url: https://joint-research-centre.ec.europa.eu/system/files/2016-06/JRC%2520Nanomaterials%2520Repository-List%2520of%2520Representative%2520Nanomaterials-201606.pdf
-   title: EUROPEAN COMMISSION JOINT RESEARCH CENTRE JRC NANOMATERIALS REPOSITORY - List of Representative Nanomaterials
-   type: report
-   format: pdf
- - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
-   title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
-   date: 2023-08-01
-   type: poster
-   format: pdf
+  - url: https://riskgone.eu/wp-content/uploads/sites/11/2022/02/RiskGONE-D5.1.pdf
+    title: Report on the final harmonised SOPs used to propose amendments to the
+      existing OECD TGs
+    date: 2021-12-29
+    type: deliverable
+    format: pdf
+  - url: https://joint-research-centre.ec.europa.eu/system/files/2016-06/JRC%2520Nanomaterials%2520Repository-List%2520of%2520Representative%2520Nanomaterials-201606.pdf
+    title: EUROPEAN COMMISSION JOINT RESEARCH CENTRE JRC NANOMATERIALS REPOSITORY -
+      List of Representative Nanomaterials
+    type: report
+    format: pdf
+  - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
+    title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
+    date: 2023-08-01
+    type: poster
+    format: pdf
+  - databases:
+      - RISKGONE
 cas: 13463-67-7
-sameAs: [JRCNM01005a]
+sameAs:
+  - JRCNM01005a

--- a/_data/erm/ERM00000065.yml
+++ b/_data/erm/ERM00000065.yml
@@ -6,18 +6,22 @@ chemicalComposition: ZnO
 tags: erm:ERM00000065
 cas: 1314-13-2
 supplier:
- - name: JRC
-   code: JRCNM01101a
+  - name: JRC
+    code: JRCNM01101a
 a: npo:NPO_1542
 otherLinks:
- - url: https://riskgone.eu/wp-content/uploads/sites/11/2022/02/RiskGONE-D5.1.pdf
-   title: Report on the final harmonised SOPs used to propose amendments to the existing OECD TGs
-   date: 2021-12-29
-   type: deliverable
-   format: pdf
- - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
-   title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
-   date: 2023-08-01
-   type: poster
-   format: pdf
-sameAs: [JRCNM01101a]
+  - url: https://riskgone.eu/wp-content/uploads/sites/11/2022/02/RiskGONE-D5.1.pdf
+    title: Report on the final harmonised SOPs used to propose amendments to the
+      existing OECD TGs
+    date: 2021-12-29
+    type: deliverable
+    format: pdf
+  - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
+    title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
+    date: 2023-08-01
+    type: poster
+    format: pdf
+  - databases:
+      - RISKGONE
+sameAs:
+  - JRCNM01101a

--- a/_data/erm/ERM00000066.yml
+++ b/_data/erm/ERM00000066.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000066"
+type: ChemicalSubstance
+id: ERM00000066
+tag: erm:ERM00000066
+tags: erm:ERM00000066
+otherLinks:
+  - databases:
+      - RISKGONE

--- a/_data/erm/ERM00000067.yml
+++ b/_data/erm/ERM00000067.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000067"
+type: ChemicalSubstance
+id: ERM00000067
+tag: erm:ERM00000067
+tags: erm:ERM00000067
+otherLinks:
+  - databases:
+      - RISKGONE

--- a/_data/erm/ERM00000083.yml
+++ b/_data/erm/ERM00000083.yml
@@ -1,4 +1,3 @@
----
 title: "Material: ERM00000083"
 type: ChemicalSubstance
 id: ERM00000083
@@ -6,12 +5,13 @@ tag: erm:ERM00000083
 tags: erm:ERM00000083
 chemicalComposition: PLGA-AuNPs-WOW
 supplier:
- - name: MyBioTech
+  - name: MyBioTech
 a: npo:NPO_707
 otherLinks:
- - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
-   title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
-   date: 2023-08-01
-   type: poster
-   format: pdf
----
+  - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
+    title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
+    date: 2023-08-01
+    type: poster
+    format: pdf
+  - databases:
+      - RISKGONE

--- a/_data/erm/ERM00000084.yml
+++ b/_data/erm/ERM00000084.yml
@@ -1,4 +1,3 @@
----
 title: "Material: ERM00000084"
 type: ChemicalSubstance
 id: ERM00000084
@@ -6,12 +5,13 @@ tag: erm:ERM00000084
 tags: erm:ERM00000084
 chemicalComposition: PLGA-AuNPs-NP
 supplier:
- - name: MyBioTech
+  - name: MyBioTech
 a: npo:NPO_707
 otherLinks:
- - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
-   title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
-   date: 2023-08-01
-   type: poster
-   format: pdf
----
+  - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
+    title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
+    date: 2023-08-01
+    type: poster
+    format: pdf
+  - databases:
+      - RISKGONE

--- a/_data/erm/ERM00000085.yml
+++ b/_data/erm/ERM00000085.yml
@@ -1,4 +1,3 @@
----
 title: "Material: ERM00000085"
 type: ChemicalSubstance
 id: ERM00000085
@@ -6,12 +5,13 @@ tag: erm:ERM00000085
 tags: erm:ERM00000085
 chemicalComposition: Au
 supplier:
- - name: MyBioTech
+  - name: MyBioTech
 a: npo:NPO_1892
 otherLinks:
- - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
-   title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
-   date: 2023-08-01
-   type: poster
-   format: pdf
----
+  - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
+    title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
+    date: 2023-08-01
+    type: poster
+    format: pdf
+  - databases:
+      - RISKGONE

--- a/_data/erm/ERM00000086.yml
+++ b/_data/erm/ERM00000086.yml
@@ -1,4 +1,3 @@
----
 title: "Material: ERM00000086"
 type: ChemicalSubstance
 id: ERM00000086
@@ -6,12 +5,13 @@ tag: erm:ERM00000086
 tags: erm:ERM00000086
 chemicalComposition: Au
 supplier:
- - name: MyBioTech
+  - name: MyBioTech
 a: npo:NPO_1892
 otherLinks:
- - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
-   title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
-   date: 2023-08-01
-   type: poster
-   format: pdf
----
+  - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
+    title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
+    date: 2023-08-01
+    type: poster
+    format: pdf
+  - databases:
+      - RISKGONE

--- a/_data/erm/ERM00000088.yml
+++ b/_data/erm/ERM00000088.yml
@@ -6,16 +6,19 @@ chemicalComposition: CuO
 tags: erm:ERM00000088
 cas: 1317-38-0
 supplier:
- - name: PlasmaChem
+  - name: PlasmaChem
 a: npo:NPO_1544
 otherLinks:
- - url: https://riskgone.eu/wp-content/uploads/sites/11/2022/02/RiskGONE-D5.1.pdf
-   title: Report on the final harmonised SOPs used to propose amendments to the existing OECD TGs
-   date: 2021-12-29
-   type: deliverable
-   format: pdf
- - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
-   title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
-   date: 2023-08-01
-   type: poster
-   format: pdf
+  - url: https://riskgone.eu/wp-content/uploads/sites/11/2022/02/RiskGONE-D5.1.pdf
+    title: Report on the final harmonised SOPs used to propose amendments to the
+      existing OECD TGs
+    date: 2021-12-29
+    type: deliverable
+    format: pdf
+  - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
+    title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
+    date: 2023-08-01
+    type: poster
+    format: pdf
+  - databases:
+      - RISKGONE

--- a/_data/erm/ERM00000089.yml
+++ b/_data/erm/ERM00000089.yml
@@ -6,17 +6,20 @@ chemicalComposition: WCCo
 tags: erm:ERM00000089
 cas: 12718-69-3
 supplier:
- - name: NanoAmor
-   code: 5561HW
+  - name: NanoAmor
+    code: 5561HW
 a: npo:ENM_9000257
 otherLinks:
- - url: https://riskgone.eu/wp-content/uploads/sites/11/2022/02/RiskGONE-D5.1.pdf
-   title: Report on the final harmonised SOPs used to propose amendments to the existing OECD TGs
-   date: 2021-12-29
-   type: deliverable
-   format: pdf
- - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
-   title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
-   date: 2023-08-01
-   type: poster
-   format: pdf
+  - url: https://riskgone.eu/wp-content/uploads/sites/11/2022/02/RiskGONE-D5.1.pdf
+    title: Report on the final harmonised SOPs used to propose amendments to the
+      existing OECD TGs
+    date: 2021-12-29
+    type: deliverable
+    format: pdf
+  - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
+    title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
+    date: 2023-08-01
+    type: poster
+    format: pdf
+  - databases:
+      - RISKGONE

--- a/_data/erm/ERM00000098.yml
+++ b/_data/erm/ERM00000098.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000098"
+type: ChemicalSubstance
+id: ERM00000098
+tag: erm:ERM00000098
+tags: erm:ERM00000098
+otherLinks:
+  - databases:
+      - SBD4NANO

--- a/_data/erm/ERM00000325.yml
+++ b/_data/erm/ERM00000325.yml
@@ -6,17 +6,20 @@ chemicalComposition: C
 tags: erm:ERM00000325
 cas: 1314-13-2
 supplier:
- - name: Nanocyl
-   code: AQUACYLTM AQ0303
+  - name: Nanocyl
+    code: AQUACYLTM AQ0303
 a: npo:NPO_354
 otherLinks:
- - url: https://riskgone.eu/wp-content/uploads/sites/11/2022/02/RiskGONE-D5.1.pdf
-   title: Report on the final harmonised SOPs used to propose amendments to the existing OECD TGs
-   date: 2021-12-29
-   type: deliverable
-   format: pdf
- - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
-   title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
-   date: 2023-08-01
-   type: poster
-   format: pdf
+  - url: https://riskgone.eu/wp-content/uploads/sites/11/2022/02/RiskGONE-D5.1.pdf
+    title: Report on the final harmonised SOPs used to propose amendments to the
+      existing OECD TGs
+    date: 2021-12-29
+    type: deliverable
+    format: pdf
+  - url: https://riskgone.eu/wp-content/uploads/sites/11/2023/08/POSTER_RiskGONE_WP4_finalCM_POSTER1.pdf
+    title: WP4 - ENMs Characterisation, in vitro dosimetry and environmental fate
+    date: 2023-08-01
+    type: poster
+    format: pdf
+  - databases:
+      - RISKGONE

--- a/_data/erm/ERM00000487.yml
+++ b/_data/erm/ERM00000487.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000487"
+type: ChemicalSubstance
+id: ERM00000487
+tag: erm:ERM00000487
+tags: erm:ERM00000487
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000488.yml
+++ b/_data/erm/ERM00000488.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000488"
+type: ChemicalSubstance
+id: ERM00000488
+tag: erm:ERM00000488
+tags: erm:ERM00000488
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000489.yml
+++ b/_data/erm/ERM00000489.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000489"
+type: ChemicalSubstance
+id: ERM00000489
+tag: erm:ERM00000489
+tags: erm:ERM00000489
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000490.yml
+++ b/_data/erm/ERM00000490.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000490"
+type: ChemicalSubstance
+id: ERM00000490
+tag: erm:ERM00000490
+tags: erm:ERM00000490
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000491.yml
+++ b/_data/erm/ERM00000491.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000491"
+type: ChemicalSubstance
+id: ERM00000491
+tag: erm:ERM00000491
+tags: erm:ERM00000491
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000492.yml
+++ b/_data/erm/ERM00000492.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000492"
+type: ChemicalSubstance
+id: ERM00000492
+tag: erm:ERM00000492
+tags: erm:ERM00000492
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000493.yml
+++ b/_data/erm/ERM00000493.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000493"
+type: ChemicalSubstance
+id: ERM00000493
+tag: erm:ERM00000493
+tags: erm:ERM00000493
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000494.yml
+++ b/_data/erm/ERM00000494.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000494"
+type: ChemicalSubstance
+id: ERM00000494
+tag: erm:ERM00000494
+tags: erm:ERM00000494
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000496.yml
+++ b/_data/erm/ERM00000496.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000496"
+type: ChemicalSubstance
+id: ERM00000496
+tag: erm:ERM00000496
+tags: erm:ERM00000496
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000497.yml
+++ b/_data/erm/ERM00000497.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000497"
+type: ChemicalSubstance
+id: ERM00000497
+tag: erm:ERM00000497
+tags: erm:ERM00000497
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000498.yml
+++ b/_data/erm/ERM00000498.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000498"
+type: ChemicalSubstance
+id: ERM00000498
+tag: erm:ERM00000498
+tags: erm:ERM00000498
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000499.yml
+++ b/_data/erm/ERM00000499.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000499"
+type: ChemicalSubstance
+id: ERM00000499
+tag: erm:ERM00000499
+tags: erm:ERM00000499
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000500.yml
+++ b/_data/erm/ERM00000500.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000500"
+type: ChemicalSubstance
+id: ERM00000500
+tag: erm:ERM00000500
+tags: erm:ERM00000500
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000501.yml
+++ b/_data/erm/ERM00000501.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000501"
+type: ChemicalSubstance
+id: ERM00000501
+tag: erm:ERM00000501
+tags: erm:ERM00000501
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000502.yml
+++ b/_data/erm/ERM00000502.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000502"
+type: ChemicalSubstance
+id: ERM00000502
+tag: erm:ERM00000502
+tags: erm:ERM00000502
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000503.yml
+++ b/_data/erm/ERM00000503.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000503"
+type: ChemicalSubstance
+id: ERM00000503
+tag: erm:ERM00000503
+tags: erm:ERM00000503
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000504.yml
+++ b/_data/erm/ERM00000504.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000504"
+type: ChemicalSubstance
+id: ERM00000504
+tag: erm:ERM00000504
+tags: erm:ERM00000504
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000505.yml
+++ b/_data/erm/ERM00000505.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000505"
+type: ChemicalSubstance
+id: ERM00000505
+tag: erm:ERM00000505
+tags: erm:ERM00000505
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000506.yml
+++ b/_data/erm/ERM00000506.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000506"
+type: ChemicalSubstance
+id: ERM00000506
+tag: erm:ERM00000506
+tags: erm:ERM00000506
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000507.yml
+++ b/_data/erm/ERM00000507.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000507"
+type: ChemicalSubstance
+id: ERM00000507
+tag: erm:ERM00000507
+tags: erm:ERM00000507
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_data/erm/ERM00000509.yml
+++ b/_data/erm/ERM00000509.yml
@@ -1,0 +1,8 @@
+title: "Material: ERM00000509"
+type: ChemicalSubstance
+id: ERM00000509
+tag: erm:ERM00000509
+tags: erm:ERM00000509
+otherLinks:
+  - databases:
+      - HARMLESS

--- a/_layouts/substance.html
+++ b/_layouts/substance.html
@@ -89,15 +89,32 @@ layout: base
 </ul>
 {% endif %}
 
-{% assign datasets = page.datasetDOI %}
-{% if datasets.size > 0 %}
-<h2 class="tag-title">Datasets</h2>
-<ul>
-{% for dataset in datasets %}
-<li><a href="../../work/{{ dataset }}" />{{ dataset }}</li></a>
+
+
+User
+{% assign databases = "" %}
+{% for link in page.otherLinks %}
+  {% if link.databases %}
+    {% assign databases = link.databases %}
+    {% break %}
+  {% endif %}
 {% endfor %}
-</ul>
+
+{% if databases.size > 0 %}
+  <h2 class="tag-title">Databases</h2>
+  <ul>
+    {% for database in databases %}
+      {% for site_database_hash in site.data.databases %}
+        {% assign site_database = site_database_hash[1] %}
+        {% if database == site_database.title %}
+          <li>{{ database }}</li>
+        {% endif %}
+      {% endfor %}      
+    {% endfor %}
+  </ul>
 {% endif %}
+
+
 
 {% assign journalArticles = page.scholarlyArticleDOI | split: ' ' %}
 {% if journalArticles.size > 0 %}
@@ -113,9 +130,11 @@ layout: base
 
 
 {% if page.otherLinks.size > 0 %}
+
 <h2 class="tag-title">Other</h2>
 <ul>
 {% for link in page.otherLinks %}
+  {% if link.title %}
   {% if link.lang %}
   <li lang="{{post.lang}}">
   {% else %}
@@ -130,6 +149,7 @@ layout: base
         <i class="fa-solid fa-file-pdf"></i>
       {% endif %}
     {% endif %}
+    {% endif %}
   </li>
 {% endfor %}
 </ul>
@@ -139,6 +159,7 @@ layout: base
 {% assign scholarlyArticles = page.scholarlyArticleDOI | split: ' ' %}
 {% assign datasetArticles = page.datasetDOI | split: ' ' %}
 {% assign doiCounts = scholarlyArticles.size | plus: datasetArticles.size %}
+
 {% if doiCounts > 0 %}
   <div class="post-footer" id="bibliographyDIV" style="visibility: hidden">
   <b class="post">Further reading</b>

--- a/_layouts/substance.html
+++ b/_layouts/substance.html
@@ -91,7 +91,6 @@ layout: base
 
 
 
-User
 {% assign databases = "" %}
 {% for link in page.otherLinks %}
   {% if link.databases %}

--- a/ambit_databases.js
+++ b/ambit_databases.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+const https = require('https');
+const yaml = require('yaml');
+
+const jsonFile = 'ambit.json';
+
+function downloadJsonFile() {
+    const file = fs.createWriteStream(jsonFile);
+    https.get('https://data.enanomapper.net/solr/metadata/select?q=name_s:ERM*&rows=1000', (response) => {
+        response.pipe(file);
+        file.on('finish', () => {
+            file.close();
+            processJsonFile();
+        });
+    }).on('error', (err) => {
+        fs.unlink(jsonFile);
+        console.error(`Error downloading JSON file: ${err.message}`);
+    });
+}
+
+function processJsonFile() {
+    if (!fs.existsSync(jsonFile)) {
+        downloadJsonFile();
+        return;
+    }
+
+    const jsonData = JSON.parse(fs.readFileSync(jsonFile));
+    const docs = jsonData.response?.docs;
+
+    if (!docs || docs.length === 0) {
+        console.log("Error: 'docs' array is null or empty in the JSON file.");
+        return;
+    }
+
+    docs.forEach(doc => {
+        const { name_s, owner_name_s: owner_name } = doc;
+        const yamlFile = `_data/erm/${name_s}.yml`;
+
+        if (!fs.existsSync(yamlFile)) {
+            const yamlContent = yaml.stringify({
+                title: `Material: ${name_s}`,
+                type: 'ChemicalSubstance',
+                id: name_s,
+                tag: `erm:${name_s}`,
+                tags: `erm:${name_s}`,
+                otherLinks: [{ databases: [owner_name] }]
+            });
+            fs.writeFileSync(yamlFile, yamlContent);
+        } else {
+            console.log(`${owner_name} ${yamlFile} ${name_s} exists`);
+            let yamlContent = fs.readFileSync(yamlFile, 'utf8');
+            const existingYamlObj = yaml.parseDocument(yamlContent).toJSON();
+            
+            if (!existingYamlObj.otherLinks) existingYamlObj.otherLinks = [];
+            
+            if (!existingYamlObj.otherLinks.some(link => link.databases && link.databases.includes(owner_name))) {
+                existingYamlObj.otherLinks.push({ databases: [owner_name] });
+                fs.writeFileSync(yamlFile, yaml.stringify(existingYamlObj));
+            }
+        }
+    });
+}
+
+processJsonFile();


### PR DESCRIPTION
Solves #18 

Added [script](https://github.com/NanoCommons/erm-database/blob/adds-ambit/ambit_databases.js) to retrieve AMBIT database info, updated and new ERM data files, a new 'databases' data source and a database list for the substances page.

For now the list in the `substance` layout displays only the database name, but if we add a link field to each database file in  `_data/databases/` we can update the list with a href
```
{% if databases.size > 0 %}
  <h2 class="tag-title">Databases</h2>
  <ul>
    {% for database in databases %}
      {% for site_database_hash in site.data.databases %}
        {% assign site_database = site_database_hash[1] %}
        {% if database == site_database.title %}
          <li>{{ database }}</li>
        {% endif %}
      {% endfor %}      
    {% endfor %}
  </ul>
{% endif %}
```

![image](https://github.com/NanoCommons/erm-database/assets/83466805/49823b6d-f88c-41d9-883d-acdbbd0195a6)
